### PR TITLE
Move React to peerDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3344,6 +3344,7 @@
       "version": "15.6.2",
       "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.2.tgz",
       "integrity": "sha1-zx7RXxKq1/FO9fLf4F5sQvke8Co=",
+      "dev": true,
       "requires": {
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
@@ -6717,6 +6718,7 @@
       "version": "15.6.2",
       "resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
       "integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
+      "dev": true,
       "requires": {
         "create-react-class": "15.6.2",
         "fbjs": "0.8.16",
@@ -6729,6 +6731,7 @@
       "version": "15.6.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.2.tgz",
       "integrity": "sha1-Qc+t9pO3V/rycIRDodH9WgK+9zA=",
+      "dev": true,
       "requires": {
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -50,15 +50,19 @@
     "gulp-rename": "^1.2.2",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-uglify": "*",
+    "react": "^15.6.2",
+    "react-dom": "^15.6.2",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0"
+  },
+  "peerDependencies": {
+    "react": "^15.6.2",
+    "react-dom": "^15.6.2"
   },
   "dependencies": {
     "d3": "^4.1.1",
     "icheck": "^1.0.2",
     "prop-types": "^15.6.0",
-    "react": "^15.6.2",
-    "react-dom": "^15.6.2",
     "react-draggable": "^2.2.0",
     "react-input-range": "1.0.2",
     "whatwg-fetch": "^2.0.3"

--- a/src/scripts/components/dateselector/wv.dateselector.input.js
+++ b/src/scripts/components/dateselector/wv.dateselector.input.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import ReactDom from 'react-dom';
 import Util from '../util/wv.utils';
 
 const util = new Util();
@@ -22,10 +21,11 @@ class DateInputColumn extends React.Component {
       value: this.props.value,
       valid: true
     };
+    this.inputs = [];
   }
   componentDidUpdate() {
     if (this.props.focused) {
-      ReactDom.findDOMNode(this.refs['input-' + this.props.tabIndex]).focus();
+      this.inputs[this.props.tabIndex].focus();
     }
   }
   componentWillMount() {
@@ -195,7 +195,7 @@ class DateInputColumn extends React.Component {
         </div>
         <input
           type="text"
-          ref={'input-' + this.props.tabIndex}
+          ref={(input) => { this.inputs[this.props.tabIndex] = input; }}
           size={this.size}
           maxLength={this.size}
           className="button-input-group"


### PR DESCRIPTION
Move React to peerDependencies to avoid loading multiple copies of React.

This is a PR instead of just adding it to `remove-shim` so that I don't break and of your work in progress @ZachTRice @Benjaki2 but give it a try, and let's merge it into the `remove-shim` branch when we can.