### PR TITLE
Update developer info

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   },
   "license": "NASA-1.3",
   "main": "./src/scripts/index.js",
-  "author": "Benjamin King <benjamin.a.king@nasa.gov>",
   "browserify-shim": {},
   "browserify": {
     "transform": [


### PR DESCRIPTION
Since this is an optional field and multiple authors and maintainers are implied, removing this field so we don't have to keep information up to date in multiple places.