### PR TITLE
Removed references to Worldview Timeline Components. Updated roadmap …

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ See [LICENSE.md](LICENSE.md)
 
 ## Contributing
 
-We'd be quite excited if you'd like to contribute to Worldview Timeline Components! Whether it's finding bugs, adding new features, fixing anything broken, or improving documentation, get started by submitting an issue or pull request!
+We'd be quite excited if you'd like to contribute to Worldview Components! Whether it's finding bugs, adding new features, fixing anything broken, or improving documentation, get started by submitting an issue or pull request!
 
 Please see our [Roadmap](https://github.com/nasa-gibs/worldview/projects/7) for a list of Worldview features currently in progress.
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,6 @@ See [LICENSE.md](LICENSE.md)
 
 We'd be quite excited if you'd like to contribute to Worldview Timeline Components! Whether it's finding bugs, adding new features, fixing anything broken, or improving documentation, get started by submitting an issue or pull request!
 
-Please see our [Roadmap](https://github.com/nasa-gibs/worldview/wiki/Worldview-Roadmap) for a list of Worldview features currently in progress.
+Please see our [Roadmap](https://github.com/nasa-gibs/worldview/projects/7) for a list of Worldview features currently in progress.
 
 Thanks for considering contributing and making our planet easier to explore!

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## About
 
-External components built to use on the [NASA Worldview](worldview.earthdata.nasa.gov) satellite imagery visualization application. Worldview Timeline Components is built using ES6 and facebook's [react](https://github.com/facebook/react/) JS library. This repository is the start of a larger project to make our code more scalable and readable.
+External components built to use on the [NASA Worldview](worldview.earthdata.nasa.gov) satellite imagery visualization application. Worldview Components is built using ES6 and facebook's [react](https://github.com/facebook/react/) JS library. This repository is the start of a larger project to make our code more scalable and readable.
 
 ## Getting Started
 
@@ -21,14 +21,14 @@ sudo npm install --global gulp-cli
 ### CommonJS
 
 #### Get Entire Package
-`var TimelineComponents = require('worldview-components');`
+`var WorldviewComponents = require('worldview-components');`
 #### Use Single Module
 `var DateSelector = require('worldview-components').DateSelector;`
 
 ### ES6
 
 #### Get Entire Package
-`import TimelineComponents from 'worldview-components';`
+`import WorldviewComponents from 'worldview-components';`
 
 #### Grab what you need
 `import {DateSelector, Tooltip} from 'worldview-components';`


### PR DESCRIPTION
Fixes nasa-gibs/worldview#727.

Changes in this pull request: 
- Changed references Worldview Timeline Components to Worldview Components
- Updated link to the current roadmap.

@nasa-gibs/worldview
 
