### PR TITLE
Format day date range if start & end are equal. Order dates descending

### DIFF
--- a/src/scripts/components/layer/row.js
+++ b/src/scripts/components/layer/row.js
@@ -127,7 +127,7 @@ class LayerRow extends React.Component {
     var listItems;
     var headerClass = 'layers-all-header has-checkbox';
     if (layer.dateRanges && layer.dateRanges.length > 1) {
-      listItems = layer.dateRanges.map((l) => {
+      listItems = layer.dateRanges.slice(0).reverse().map((l) => {
         let startDate = util.parseDate(l.startDate);
         let endDate = util.parseDate(l.endDate);
         if (layer.period === 'subdaily') {
@@ -155,6 +155,11 @@ class LayerRow extends React.Component {
           return <ListGroupItem key={l.startDate}>
             {(startDate).getDate() + ' ' + util.giveMonth(startDate) + ' - ' +
             (endDate).getDate() + ' ' + util.giveMonth(endDate)}
+          </ListGroupItem>;
+        } else if (layer.period === 'daily' && l.startDate === l.endDate) {
+          return <ListGroupItem key={l.startDate + ' - ' + l.endDate}>
+            {(startDate).getDate() + ' ' + util.giveMonth(startDate) + ' ' +
+            (startDate).getFullYear()}
           </ListGroupItem>;
         } else {
           return <ListGroupItem key={l.startDate + ' - ' + l.endDate}>


### PR DESCRIPTION
## Description

Connects to nasa-gibs/worldview#384

If a layer is a daily layer and it's start and end dates are the same, only a single date is output instead of a range.

Date ranges / dates are formatted in descending order.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Lint and unit tests pass locally with my changes (`npm run test`)
- [x] Any dependent changes have been merged and published in downstream modules

@nasa-gibs/worldview
