### PR TITLE
Dateline hover text wv1063

### DIFF
--- a/src/scripts/components/dateline/dateline.js
+++ b/src/scripts/components/dateline/dateline.js
@@ -109,7 +109,7 @@ Line.defaultProps = {
   color: 'white',
   height: 200,
   svgStyle: {
-    padding: '0 40px 0 40px',
+    margin: '0 40px 0 40px',
     transform: 'translateX(-43px)'
   }
 };


### PR DESCRIPTION
## Description

Fixes nasa-gibs/worldview#1063

- Change dateline svg padding to margin so inner line is hoverable (issue caused by BS border-box)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Lint and unit tests pass locally with my changes (`npm run test`)
- [x] Any dependent changes have been merged and published in downstream modules

@nasa-gibs/worldview
