### PR TITLE
Prevent start dragger from dragging both draggers off the timeline into the 'future'

### DIFF
--- a/src/scripts/components/range-selection/range-selection.js
+++ b/src/scripts/components/range-selection/range-selection.js
@@ -53,8 +53,12 @@ class TimelineRangeSelector extends React.Component {
       if (startX < 0 || startX > endX) {
         return;
       }
-      if (startX + (2 * this.props.pinWidth) >= endX) {
-        endX = startX + this.props.pinWidth;
+      if (startX + this.props.pinWidth >= endX) {
+        if (startX + this.props.pinWidth >= this.state.max) {
+          return;
+        } else {
+          endX = startX + this.props.pinWidth;
+        }
       }
     } else if (id === 'end') {
       startX = this.state.startLocation;


### PR DESCRIPTION
## Description

Fixes #[1105](https://github.com/nasa-gibs/worldview/issues/1105) in Worldview main.

- Previously, when moving the start dragger beyond the end dragger, the end dragger position would update to the start dragger position. This caused the start dragger to be able to drag both draggers beyond the max (current date) and off of the timeline.
- This fix adds a condition to prevent dragging beyond max

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Lint and unit tests pass locally with my changes (`npm run test`)
- [x] Any dependent changes have been merged and published in downstream modules

@nasa-gibs/worldview
