### PR TITLE
Fix product picker info buttons expand multiple layers at once

### DIFF
--- a/src/scripts/components/layer/list.js
+++ b/src/scripts/components/layer/list.js
@@ -31,6 +31,7 @@ class LayerList extends React.Component {
     var { filteredLayers, expandedMetadataLayers } = this.state;
     var isMetadataExpanded = expandedMetadataLayers.find(id => id === layerId);
     if (isMetadataExpanded) {
+      expandedMetadataLayers.splice(expandedMetadataLayers.indexOf(layerId), 1);
       expandedMetadataLayers = expandedMetadataLayers.filter(id => id !== layerId);
     } else {
       expandedMetadataLayers.push(layerId);


### PR DESCRIPTION
## Description

Fixes nasa-gibs/worldview#624

When clicking an info box in the search results, closing it and then clicking another, both info boxes pop open.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Lint and unit tests pass locally with my changes (`npm run test`)
- [x] Any dependent changes have been merged and published in downstream modules

@nasa-gibs/worldview
