### PR TITLE
Properly set state within componentWillReceiveProps

### DIFF
--- a/src/scripts/components/layer/row.js
+++ b/src/scripts/components/layer/row.js
@@ -191,11 +191,11 @@ class LayerRow extends React.Component {
   };
 
   componentWillReceiveProps(nextProps) {
-    this.state = {
+    this.setState({
       checked: nextProps.isEnabled,
       isMetadataExpanded: nextProps.isMetadataExpanded,
       isDateRangesExpanded: nextProps.isDateRangesExpanded
-    };
+    });
   }
 
   render() {


### PR DESCRIPTION
## Description

Fixes nasa-gibs/worldview#1145

Uses `this.setState()` rather than `this.state =` within `componentsWillReceiveProps()`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Lint and unit tests pass locally with my changes (`npm run test`)
- [x] Any dependent changes have been merged and published in downstream modules

@nasa-gibs/worldview
