### PR TITLE
When KMZ is selected, disable worldfile select (and default to 'No')

### DIFF
--- a/src/scripts/components/image-panel/select.js
+++ b/src/scripts/components/image-panel/select.js
@@ -67,13 +67,18 @@ export default class ImageResSelection extends React.Component {
     if (this.props.worldFileOptions) {
       return (
         <div className='wv-image-header'>
-          <select
-            id='wv-image-worldfile'
-            value={this.state.worldfile}
-            onChange={(e) => this.handleChange('worldfile', e.target.value)}>
-            <option value='false'>No</option>
-            <option value='true'>Yes</option>
-          </select>
+
+          {this.state.fileType === 'image/kmz'
+            ? <select disabled>
+              <option value='false'>No</option>
+            </select>
+            : <select
+              id='wv-image-worldfile'
+              value={this.state.worldfile}
+              onChange={(e) => this.handleChange('worldfile', e.target.value)}>
+              <option value='false'>No</option>
+              <option value='true'>Yes</option>
+            </select> }
           Worldfile (.zip)
         </div>
       );


### PR DESCRIPTION
## Description

Fixes nasa-gibs/worldview#301

Disables the worldfile select box (and defaults the option to "No") when the KMZ filetype is selected.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Lint and unit tests pass locally with my changes (`npm run test`)
- [x] Any dependent changes have been merged and published in downstream modules

@nasa-gibs/worldview
