### PR TITLE
Adjust yearly layer date range

### DIFF
--- a/src/scripts/components/layer/row.js
+++ b/src/scripts/components/layer/row.js
@@ -93,14 +93,10 @@ class LayerRow extends React.Component {
           endDate.getFullYear() + ' ' + util.pad(endDate.getHours(), 2, '0') + ':' +
           util.pad(endDate.getMinutes(), 2, '0');
         } else if (layer.period === 'yearly') {
-          if (layer.dateRanges && layer.dateRanges.slice(-1)[0].dateInterval !== '1') {
-            endDate = new Date(endDate.setFullYear(endDate.getFullYear() - 1));
-          }
+          endDate = new Date(endDate.setFullYear(endDate.getFullYear() - 1));
           endDate = endDate.getFullYear();
         } else if (layer.period === 'monthly') {
-          if (layer.dateRanges && layer.dateRanges.slice(-1)[0].dateInterval !== '1') {
-            endDate = new Date(endDate.setMonth(endDate.getMonth() - 1));
-          }
+          endDate = new Date(endDate.setMonth(endDate.getMonth() - 1));
           endDate = util.giveMonth(endDate) + ' ' + endDate.getFullYear();
         } else {
           if (layer.dateRanges && layer.dateRanges.slice(-1)[0].dateInterval !== '1') {


### PR DESCRIPTION
## Description

Fixes nasa-gibs/worldview#1166

This PR adjusts the layer date range to coincide with the changes made in nasa-gibs/worldview#1165

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Lint and unit tests pass locally with my changes (`npm run test`)
- [x] Any dependent changes have been merged and published in downstream modules

@nasa-gibs/worldview
